### PR TITLE
Fix active-low pixel logic for panel

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -24,10 +24,10 @@ void setup() {
 void loop() {
   static uint16_t pixel = 0;         // aktuelles Pixel (0–255)
   uint8_t frame[32];                 // 16*16 Bits / 8 = 32 Bytes
-  memset(frame, 0, sizeof(frame));
+  memset(frame, 0xFF, sizeof(frame));
 
-  // einzelnes Pixel setzen
-  frame[pixel >> 3] = 0x80 >> (pixel & 7);
+  // einzelnes Pixel setzen (active low)
+  frame[pixel >> 3] &= ~(0x80 >> (pixel & 7));
 
   shiftOutBuffer(frame, sizeof(frame));
 


### PR DESCRIPTION
## Summary
- invert frame bits so only one LED is on at a time on active-low panels

## Testing
- `./bin/arduino-cli compile --fqbn esp8266:esp8266:d1_mini IkeaObegraensad.ino` (fails: network is unreachable, platform not installed)


------
https://chatgpt.com/codex/tasks/task_e_68c543bd04a48324af97fc94fa16bf8f