### PR TITLE
Disable LEDs during SPI data shift

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -9,9 +9,11 @@ const uint8_t PIN_DATA   = D3;   // GPIO13, MOSI
 // optional: const uint8_t PIN_BUTTON = D4; // GPIO2
 
 void shiftOutBuffer(uint8_t *buffer, size_t size) {
+  digitalWrite(PIN_ENABLE, HIGH);
   digitalWrite(PIN_LATCH, LOW);
   SPI.writeBytes(buffer, size);
   digitalWrite(PIN_LATCH, HIGH);
+  digitalWrite(PIN_ENABLE, LOW);
 }
 
 void setup() {


### PR DESCRIPTION
## Summary
- Ensure LEDs are disabled while shifting data into the registers
- Re-enable LEDs after latching the new frame

## Testing
- `./bin/arduino-cli compile --fqbn esp8266:esp8266:d1_mini IkeaObegraensad.ino` *(failed: network is unreachable, platform esp8266:esp8266 not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68c5453e3a848324b684efd603fa93fc