### PR TITLE
Fix single pixel display with debug logging

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -8,31 +8,44 @@ const uint8_t PIN_CLOCK  = D5;   // GPIO14, SCK
 const uint8_t PIN_DATA   = D3;   // GPIO13, MOSI
 // optional: const uint8_t PIN_BUTTON = D4; // GPIO2
 
+// Pixel in der Mitte des 16x16 Feldes
+const uint16_t MID_PIXEL = (8 * 16) + 8;
+
 void shiftOutBuffer(uint8_t *buffer, size_t size) {
+  Serial.println("Sende Frame");
   digitalWrite(PIN_ENABLE, HIGH);
   digitalWrite(PIN_LATCH, LOW);
   SPI.writeBytes(buffer, size);
   digitalWrite(PIN_LATCH, HIGH);
   digitalWrite(PIN_ENABLE, LOW);
+  Serial.println("Frame gesendet");
 }
 
 void setup() {
+  Serial.begin(115200);
+  Serial.println("Setup gestartet");
   pinMode(PIN_ENABLE, OUTPUT);
   pinMode(PIN_LATCH,  OUTPUT);
   SPI.begin();                       // nutzt automatisch D5/D7
   digitalWrite(PIN_ENABLE, LOW);     // LEDs aktivieren
+  Serial.println("Setup fertig");
 }
 
 void loop() {
-  static uint16_t pixel = 0;         // aktuelles Pixel (0–255)
   uint8_t frame[32];                 // 16*16 Bits / 8 = 32 Bytes
-  memset(frame, 0xFF, sizeof(frame));
+  memset(frame, 0x00, sizeof(frame));
 
-  // einzelnes Pixel setzen (active low)
-  frame[pixel >> 3] &= ~(0x80 >> (pixel & 7));
+  // einzelnes Pixel setzen (active high)
+  frame[MID_PIXEL >> 3] |= (0x80 >> (MID_PIXEL & 7));
+
+  Serial.print("Frame-Inhalt: ");
+  for (uint8_t i = 0; i < sizeof(frame); ++i) {
+    Serial.print(frame[i], HEX);
+    Serial.print(' ');
+  }
+  Serial.println();
 
   shiftOutBuffer(frame, sizeof(frame));
 
-  pixel = (pixel + 1) % 256;         // nächstes Pixel
-  delay(100);                        // Tempo anpassen
+  delay(1000);
 }


### PR DESCRIPTION
## Summary
- Light only the middle pixel of the 16x16 matrix
- Add serial debug output for setup, frame contents, and buffer shifting

## Testing
- ⚠️ `arduino-cli compile` *(missing arduino-cli: Unable to locate package arduino-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c547077f3c83248ac935e711f8d237