### PR TITLE
Use active-low frame buffer

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -33,10 +33,10 @@ void setup() {
 
 void loop() {
   uint8_t frame[32];                 // 16*16 Bits / 8 = 32 Bytes
-  memset(frame, 0x00, sizeof(frame));
+  memset(frame, 0xFF, sizeof(frame));
 
-  // einzelnes Pixel setzen (active high)
-  frame[MID_PIXEL >> 3] |= (0x80 >> (MID_PIXEL & 7));
+  // einzelnes Pixel setzen (active-low buffer)
+  frame[MID_PIXEL >> 3] &= ~(0x80 >> (MID_PIXEL & 7));
 
   Serial.print("Frame-Inhalt: ");
   for (uint8_t i = 0; i < sizeof(frame); ++i) {


### PR DESCRIPTION
## Summary
- Initialize frame buffer to 0xFF so pixels default off
- Clear center pixel's bit to turn it on in active-low buffer
- Clarify comment about active-low pixel logic

## Testing
- `arduino-cli core update-index` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c5483f00f4832493df9ab01c49f859