### PR TITLE
Add helper functions for active-low frame handling

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -11,6 +11,21 @@ const uint8_t PIN_DATA   = D3;   // GPIO13, MOSI
 // Pixel in der Mitte des 16x16 Feldes
 const uint16_t MID_PIXEL = (8 * 16) + 8;
 
+// Hilfsfunktionen für den aktiven Low-Frame
+void clearFrame(uint8_t *buffer, size_t size) {
+  // setzt alle Bits auf 1 = LEDs aus
+  memset(buffer, 0xFF, size);
+}
+
+void setPixel(uint8_t *buffer, uint16_t index, bool on) {
+  uint8_t mask = 0x80 >> (index & 7);
+  if (on) {
+    buffer[index >> 3] &= ~mask;   // Bit auf 0 -> LED an
+  } else {
+    buffer[index >> 3] |= mask;    // Bit auf 1 -> LED aus
+  }
+}
+
 void shiftOutBuffer(uint8_t *buffer, size_t size) {
   Serial.println("Sende Frame");
   digitalWrite(PIN_ENABLE, HIGH);
@@ -33,10 +48,10 @@ void setup() {
 
 void loop() {
   uint8_t frame[32];                 // 16*16 Bits / 8 = 32 Bytes
-  memset(frame, 0xFF, sizeof(frame));
+  clearFrame(frame, sizeof(frame));  // alle LEDs aus
 
-  // einzelnes Pixel setzen (active-low buffer)
-  frame[MID_PIXEL >> 3] &= ~(0x80 >> (MID_PIXEL & 7));
+  // einzelnes Pixel in der Mitte aktivieren
+  setPixel(frame, MID_PIXEL, true);
 
   Serial.print("Frame-Inhalt: ");
   for (uint8_t i = 0; i < sizeof(frame); ++i) {


### PR DESCRIPTION
## Summary
- Add `clearFrame` helper to initialize the 32-byte frame with LEDs off
- Add `setPixel` helper for active-low bit manipulation
- Use the new helpers in the main loop to light the center pixel

## Testing
- `GODEBUG=netdns=go+noipv6 arduino-cli core update-index` *(fails: dial tcp 104.18.10.21:443: connect: network is unreachable)*
- `GODEBUG=netdns=go+noipv6 arduino-cli compile --fqbn esp8266:esp8266:d1_mini .` *(fails: platform esp8266:esp8266 not found; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c54917ef7c8324a7848d5d15c4496e