### PR TITLE
Use secrets header for WiFi credentials

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -7,8 +7,7 @@
 #include "effects/Snake.h"
 #include "effects/Clock.h"
 #include "effects/Rain.h"
-
-
+#include "secrets.h"
 
 ESP8266WebServer server(80);
 Effect *currentEffect = &snakeEffect;

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ effects. The matrix is updated via SPI using custom display routines.
 Connect to the device's WiFi network and open the root page to switch
 effects.
 
-Replace the `ssid` and `password` constants in `IkeaObegraensad.ino`
-with your own network credentials before uploading.
+To configure WiFi access, copy `secrets_template.h` to `secrets.h` and replace
+the placeholder `ssid` and `password` values with your network credentials
+before uploading.

--- a/secrets_template.h
+++ b/secrets_template.h
@@ -1,3 +1,3 @@
-// TODO: Replace with your WiFi credentials
+// Copy this file to secrets.h and replace with your WiFi credentials
 const char *ssid = "YOUR_SSID";
 const char *password = "YOUR_PASSWORD";


### PR DESCRIPTION
## Summary
- include `secrets.h` for WiFi credentials instead of hardcoding
- document secrets handling in README
- provide a template `secrets_template.h`

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c550718cec83248d548bb721e237d8