### PR TITLE
feat: show large two-line clock

### DIFF
--- a/Clock.h
+++ b/Clock.h
@@ -6,31 +6,28 @@
 #include <time.h>
 
 namespace ClockEffect {
-  const uint8_t DIGITS[10][5] = {
-    {0b111,0b101,0b101,0b101,0b111},
-    {0b010,0b110,0b010,0b010,0b111},
-    {0b111,0b001,0b111,0b100,0b111},
-    {0b111,0b001,0b111,0b001,0b111},
-    {0b101,0b101,0b111,0b001,0b001},
-    {0b111,0b100,0b111,0b001,0b111},
-    {0b111,0b100,0b111,0b101,0b111},
-    {0b111,0b001,0b010,0b010,0b010},
-    {0b111,0b101,0b111,0b101,0b111},
-    {0b111,0b101,0b111,0b001,0b111}
+  // 5x7 pixel font for digits 0-9
+  const uint8_t DIGITS[10][7] = {
+    {0x0e,0x11,0x11,0x11,0x11,0x11,0x0e}, // 0
+    {0x04,0x0c,0x04,0x04,0x04,0x04,0x0e}, // 1
+    {0x0e,0x11,0x01,0x02,0x04,0x08,0x1f}, // 2
+    {0x0e,0x11,0x01,0x06,0x01,0x11,0x0e}, // 3
+    {0x02,0x06,0x0a,0x12,0x1f,0x02,0x02}, // 4
+    {0x1f,0x10,0x1e,0x01,0x01,0x11,0x0e}, // 5
+    {0x06,0x08,0x10,0x1e,0x11,0x11,0x0e}, // 6
+    {0x1f,0x01,0x02,0x04,0x08,0x08,0x08}, // 7
+    {0x0e,0x11,0x11,0x0e,0x11,0x11,0x0e}, // 8
+    {0x0e,0x11,0x11,0x0f,0x01,0x02,0x0c}  // 9
   };
 
-  void drawDigit(uint8_t *frame, int digit, uint8_t xOffset) {
-    for (uint8_t y = 0; y < 5; ++y) {
-      for (uint8_t x = 0; x < 3; ++x) {
-        bool on = DIGITS[digit][y] & (1 << (2 - x));
-        if (on) setPixel(frame, x + xOffset, y + 5, true);
+  void drawDigit(uint8_t *frame, int digit, uint8_t xOffset, uint8_t yOffset) {
+    for (uint8_t y = 0; y < 7; ++y) {
+      uint8_t row = DIGITS[digit][y];
+      for (uint8_t x = 0; x < 5; ++x) {
+        bool on = row & (1 << (4 - x));
+        if (on) setPixel(frame, x + xOffset, y + yOffset, true);
       }
     }
-  }
-
-  void drawColon(uint8_t *frame) {
-    setPixel(frame, 7, 6, true);
-    setPixel(frame, 7, 8, true);
   }
 
   inline void init() {
@@ -40,13 +37,15 @@ namespace ClockEffect {
   inline void draw(uint8_t *frame) {
     time_t now = time(nullptr);
     struct tm *t = localtime(&now);
-    int h = t->tm_hour;
-    int m = t->tm_min;
-    drawDigit(frame, h / 10, 0);
-    drawDigit(frame, h % 10, 4);
-    drawColon(frame);
-    drawDigit(frame, m / 10, 9);
-    drawDigit(frame, m % 10, 13);
+    int h = t ? t->tm_hour : 0;
+    int m = t ? t->tm_min : 0;
+    // Center two digits horizontally. Hours on top, minutes on bottom.
+    const uint8_t x0 = 2;      // left margin
+    const uint8_t gap = 6;     // digit width (5) + 1 space
+    drawDigit(frame, h / 10, x0, 0);
+    drawDigit(frame, h % 10, x0 + gap, 0);
+    drawDigit(frame, m / 10, x0, 9);
+    drawDigit(frame, m % 10, x0 + gap, 9);
   }
 }
 


### PR DESCRIPTION
## Summary
- render a large 5x7 font clock with hours on top and minutes below
- center digits horizontally with bright text on a dark matrix

## Testing
- `arduino-cli compile --fqbn esp8266:esp8266:d1_mini .` *(fails: command not found)*
- `apt-get install -y arduino-cli` *(fails: Unable to locate package arduino-cli)*
- `g++ -std=c++17 -c Clock.h` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c5576ce61c8324bae86409e29f1214