### PR TITLE
fix: invert pixel bit logic for correct display

### DIFF
--- a/Matrix.h
+++ b/Matrix.h
@@ -18,16 +18,16 @@ inline void matrixSetup() {
 }
 
 inline void clearFrame(uint8_t *buffer, size_t size) {
-  memset(buffer, 0xFF, size); // all bits high -> LEDs off
+  memset(buffer, 0x00, size); // all bits low -> LEDs off
 }
 
 inline void setPixel(uint8_t *buffer, uint8_t x, uint8_t y, bool on) {
   uint16_t index = y * 16 + x;
   uint8_t mask = 0x80 >> (index & 7);
   if (on) {
-    buffer[index >> 3] &= ~mask; // bit 0 -> LED on
+    buffer[index >> 3] |= mask;  // bit 1 -> LED on
   } else {
-    buffer[index >> 3] |= mask;  // bit 1 -> LED off
+    buffer[index >> 3] &= ~mask; // bit 0 -> LED off
   }
 }
 


### PR DESCRIPTION
## Summary
- Invert frame buffer handling so LEDs turn on with bit value 1 and off with 0

## Testing
- `g++ -std=c++17 -c Matrix.h` *(fails: fatal error: Arduino.h: No such file or directory)*
- `apt-get install -y arduino-core` *(fails: unable to configure ca-certificates-java)*

------
https://chatgpt.com/codex/tasks/task_e_68c55914b8f8832494168a51b8aabc81