### PR TITLE
Light first and last pixels for debugging

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -58,12 +58,10 @@ void setup() {
 
 uint8_t frame[32];
   clearFrame(frame, sizeof(frame));
-  setPixel(frame, 0, 0, true);      // oben links
-  setPixel(frame, 15, 0, true);     // oben rechts
-  setPixel(frame, 0, 15, true);     // unten links
-  setPixel(frame, 15, 15, true);    // unten rechts
+  setPixel(frame, 0, 0, true);      // first pixel
+  setPixel(frame, 15, 15, true);    // last pixel
   shiftOutBuffer(frame, sizeof(frame));
-  delay(5000);                      // Anzeige für 5 Sekunde
+  delay(5000);                      // Anzeige für 5 Sekunden
 
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);


### PR DESCRIPTION
## Summary
- Show only first and last LED pixels to verify 16x16 panel addressing

## Testing
- `arduino-cli compile --fqbn esp8266:esp8266:d1_mini IkeaObegraensad.ino` *(fails: Platform 'esp8266:esp8266' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c569bad54c832490faecf5657d1ae3