### PR TITLE
Light first and last pixels for debugging

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -58,12 +58,10 @@ void setup() {
 
 uint8_t frame[32];
   clearFrame(frame, sizeof(frame));
-  setPixel(frame, 0, 0, true);      // oben links
-  setPixel(frame, 15, 0, true);     // oben rechts
-  setPixel(frame, 0, 15, true);     // unten links
-  setPixel(frame, 15, 15, true);    // unten rechts
+  setPixel(frame, 0, 0, true);      // first pixel
+  setPixel(frame, 15, 15, true);    // last pixel
   shiftOutBuffer(frame, sizeof(frame));
-  delay(5000);                      // Anzeige für 5 Sekunde
+  delay(5000);                      // Anzeige für 5 Sekunden
 
   WiFi.mode(WIFI_STA);
   WiFi.begin(ssid, password);

--- a/Matrix.h
+++ b/Matrix.h
@@ -22,6 +22,9 @@ inline void clearFrame(uint8_t *buffer, size_t size) {
 }
 
 inline void setPixel(uint8_t *buffer, uint8_t x, uint8_t y, bool on) {
+  if ((y & 1) == 0) {
+    x = 15 - x;               // even rows are wired right-to-left
+  }
   uint16_t index = y * 16 + x;
   uint8_t mask = 0x80 >> (index & 7);
   if (on) {


### PR DESCRIPTION
## Summary
- Reverse even rows in `setPixel` to match serpentine LED wiring so first and last pixels map to top-left and bottom-right

## Testing
- `arduino-cli core update-index` *(fails: network is unreachable)*
- `arduino-cli compile --fqbn esp8266:esp8266:d1_mini IkeaObegraensad.ino` *(fails: Platform 'esp8266:esp8266' not found due to missing index)*

------
https://chatgpt.com/codex/tasks/task_e_68c569bad54c832490faecf5657d1ae3