### PR TITLE
Enable interactive web UI with timezone configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Arduino project for the IKEA OBEGRÄNSAD LED matrix. A small web server
 running on a D1 mini (ESP8266) lets you choose between multiple visual
-effects. The matrix is updated via SPI using custom display routines. A
-global NTP client keeps the device's clock in sync so the current time can
-be displayed both on the matrix and in the web interface.
+effects and configure the device on the fly. The matrix is updated via SPI
+using custom display routines. A global NTP client keeps the device's clock
+in sync so the current time can be displayed both on the matrix and in the
+web interface.
 
 ## Available Effects
 
@@ -16,8 +17,10 @@ be displayed both on the matrix and in the web interface.
 * **Lines** – moving vertical stripes sweeping across the matrix
 
 Connect to the device's WiFi network and open the root page to switch
-effects. The page displays the current time from the NTP server and offers
-styled buttons for easier navigation.
+effects. The page shows the current time and effect and updates without a
+full page reload. A dropdown allows changing effects instantly and the
+timezone can be adjusted interactively (defaulting to Europe/Berlin with
+automatic daylight saving time).
 
 To configure WiFi access, copy `secrets_template.h` to `secrets.h` and replace
 the placeholder `ssid` and `password` values with your network credentials


### PR DESCRIPTION
## Summary
- Revamp root web page to update time and settings without reloading
- Add API endpoints to query status and change timezone dynamically
- Default timezone to Europe/Berlin with automatic DST handling

## Testing
- `./bin/arduino-cli compile --fqbn esp8266:esp8266:d1_mini .` *(fails: Platform 'esp8266:esp8266' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67ca4c0008324af7c713fdc18a387