### PR TITLE
Add Sand Clock effect toggle and register remaining effects

### DIFF
--- a/IkeaObegraensad.ino
+++ b/IkeaObegraensad.ino
@@ -19,11 +19,12 @@ extern "C" {
 #include "secrets.h"
 #include "WebInterface.h"
 #include "Pulse.h"
-#include "Waves.h" 
+#include "Waves.h"
 #include "Spiral.h"
 #include "Fire.h"
 #include "Plasma.h"
 #include "Ripple.h"
+#include "SandClock.h"
 
 ESP8266WebServer server(80);
 bool serverStarted = false;
@@ -38,7 +39,21 @@ const uint16_t EEPROM_BRIGHTNESS_ADDR = 1;
 
 const uint8_t BUTTON_PIN = D4;
 
-Effect *effects[] = {&snakeEffect, &clockEffect, &rainEffect, &bounceEffect, &starsEffect, &linesEffect};
+Effect *effects[] = {
+  &snakeEffect,
+  &clockEffect,
+  &rainEffect,
+  &bounceEffect,
+  &starsEffect,
+  &linesEffect,
+  &pulseEffect,
+  &wavesEffect,
+  &spiralEffect,
+  &fireEffect,
+  &plasmaEffect,
+  &rippleEffect,
+  &sandClockEffect
+};
 const uint8_t effectCount = sizeof(effects) / sizeof(effects[0]);
 uint8_t currentEffectIndex = 1; // start with clock
 Effect *currentEffect = effects[currentEffectIndex];
@@ -76,7 +91,8 @@ void handleStatus() {
   String json = String("{\"time\":\"") + buf +
                 "\",\"effect\":\"" + currentEffect->name +
                 "\",\"tz\":\"" + tzString +
-                "\",\"brightness\":" + String(brightness) + "}";
+                "\",\"brightness\":" + String(brightness) +
+                ",\"sandEnabled\":" + (SandClockEffect::sandEffectEnabled ? "true" : "false") + "}";
   server.send(200, "application/json", json);
 }
 
@@ -252,6 +268,19 @@ void setup() {
   server.on("/effect/bounce", []() { selectEffect(3); });
   server.on("/effect/stars", []() { selectEffect(4); });
   server.on("/effect/lines", []() { selectEffect(5); });
+  server.on("/effect/pulse", []() { selectEffect(6); });
+  server.on("/effect/waves", []() { selectEffect(7); });
+  server.on("/effect/spiral", []() { selectEffect(8); });
+  server.on("/effect/fire", []() { selectEffect(9); });
+  server.on("/effect/plasma", []() { selectEffect(10); });
+  server.on("/effect/ripple", []() { selectEffect(11); });
+  server.on("/effect/sandclock", []() { selectEffect(12); });
+  server.on("/api/toggleSand", []() {
+    toggleSandEffect();
+    server.send(200, "application/json",
+                String("{\"sandEnabled\":") +
+                (SandClockEffect::sandEffectEnabled ? "true" : "false") + "}");
+  });
   if (wifiConnected) {
     server.begin();
     serverStarted = true;

--- a/WebInterface.h
+++ b/WebInterface.h
@@ -234,7 +234,15 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawl(
             <option value="bounce">Bounce</option>
             <option value="stars">Stars</option>
             <option value="lines">Lines</option>
+            <option value="pulse">Pulse</option>
+            <option value="waves">Waves</option>
+            <option value="spiral">Spiral</option>
+            <option value="fire">Fire</option>
+            <option value="plasma">Plasma</option>
+            <option value="ripple">Ripple</option>
+            <option value="sandclock">Sand Clock</option>
           </select>
+          <button id="toggleSand" type="button">Sand-Effekt: <span id="sandStatus">An</span></button>
         </div>
         <div>
           <label for="tz">Zeitzone (POSIX)</label>
@@ -271,8 +279,26 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawl(
     const brightnessValue = document.getElementById('brightnessValue');
     const saveBrightnessButton = document.getElementById('saveBrightness');
     const statusMessage = document.getElementById('statusMessage');
+    const toggleSandButton = document.getElementById('toggleSand');
+    const sandStatus = document.getElementById('sandStatus');
 
     let brightnessDebounce;
+
+    const effectLabels = {
+      snake: 'Snake',
+      clock: 'Clock',
+      rain: 'Rain',
+      bounce: 'Bounce',
+      stars: 'Stars',
+      lines: 'Lines',
+      pulse: 'Pulse',
+      waves: 'Waves',
+      spiral: 'Spiral',
+      fire: 'Fire',
+      plasma: 'Plasma',
+      ripple: 'Ripple',
+      sandclock: 'Sand Clock'
+    };
 
     function showStatus(message, type = 'info') {
       statusMessage.textContent = message;
@@ -280,7 +306,7 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawl(
     }
 
     function prettifyEffect(effect) {
-      return effect.charAt(0).toUpperCase() + effect.slice(1);
+      return effectLabels[effect] || (effect.charAt(0).toUpperCase() + effect.slice(1));
     }
 
     function updateBrightnessUI(value) {
@@ -307,10 +333,26 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawl(
           tzInput.value = data.tz || '';
         }
         updateBrightnessUI(data.brightness);
-        effectSelect.value = data.effect;
+        if ([...effectSelect.options].some(option => option.value === data.effect)) {
+          effectSelect.value = data.effect;
+        }
+        if (data.sandEnabled !== undefined) {
+          sandStatus.textContent = data.sandEnabled ? 'An' : 'Aus';
+        }
         showStatus('');
       } catch (error) {
         showStatus('Status konnte nicht geladen werden. ' + error.message, 'error');
+      }
+    }
+
+    async function toggleSandEffect() {
+      try {
+        const response = await fetch('/api/toggleSand');
+        const data = await response.json();
+        sandStatus.textContent = data.sandEnabled ? 'An' : 'Aus';
+        showStatus('Sand-Effekt ' + (data.sandEnabled ? 'aktiviert' : 'deaktiviert'));
+      } catch (error) {
+        showStatus('Fehler beim Umschalten', 'error');
       }
     }
 
@@ -366,6 +408,8 @@ const char WEB_INTERFACE_HTML[] PROGMEM = R"rawl(
     saveBrightnessButton.addEventListener('click', () => {
       saveBrightness(brightnessSlider.value);
     });
+
+    toggleSandButton.addEventListener('click', toggleSandEffect);
 
     refreshStatus();
     setInterval(refreshStatus, 2000);


### PR DESCRIPTION
## Summary
- expose the Sand Clock effect through the API, status response, and toggle endpoint while wiring up remaining animation routes
- extend the web UI to list all effects, add a Sand Clock toggle control, and show the toggle state from status updates

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d833ab168083249b8c6bb425652109